### PR TITLE
Add support for schema role grant inheritance in db clones

### DIFF
--- a/snowddl/blueprint/blueprint.py
+++ b/snowddl/blueprint/blueprint.py
@@ -65,6 +65,7 @@ class DatabaseBlueprint(AbstractBlueprint):
     is_transient: Optional[bool] = None
     retention_time: Optional[int] = None
     is_sandbox: Optional[bool] = None
+    copy_schema_role_grants_to_db_clones: List[str] = []
 
 
 class DatabaseShareBlueprint(AbstractBlueprint):

--- a/snowddl/parser/database.py
+++ b/snowddl/parser/database.py
@@ -17,6 +17,12 @@ database_json_schema = {
         },
         "comment": {
             "type": "string"
+        },
+        "copy_schema_role_grants_to_db_clones": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "additionalProperties": False
@@ -42,6 +48,7 @@ class DatabaseParser(AbstractParser):
                 retention_time=params.get("retention_time", None),
                 is_sandbox=params.get("is_sandbox", False),
                 comment=params.get("comment", None),
+                copy_schema_role_grants_to_db_clones=params.get("copy_schema_role_grants_to_db_clones", [])
             )
 
             self.config.add_blueprint(bp)


### PR DESCRIPTION
## Overview
Cloning operations in Snowflake typically don't work well for objects managed by IaC tools like SnowDDL, because when grants get copied from source to target, it creates resource drift between the IaC config and the Snowflake state

For example, suppose a database `ANALYTICS` is managed by SnowDDL and a schema role `ANALYTICS__STAGING__OWNER__R_ROLE` is created with the following grant:

```sql
GRANT USAGE ON SCHEMA ANALYTICS.STAGING TO ROLE ANALYTICS__STAGING__OWNER__R_ROLE;
```

If a clone operation is executed, that grant gets copied to the cloned db. For example:

```sql
CREATE DATABASE ANALYTICS_CLONE CLONE ANALYTICS;`
```

results in the following grant (under the hood, Snowflake copies it automatically):

```sql
GRANT USAGE ON SCHEMA ANALYTICS_CLONE.STAGING TO ROLE ANALYTICS__STAGING__OWNER__R_ROLE;
```

The next time SnowDDL runs, it detects this additional grant as resource drift and tries to revoke it:

```sql
REVOKE USAGE ON SCHEMA ANALYTICS_CLONE.STAGING FROM ROLE ANALYTICS__STAGING__OWNER__R_ROLE;
```

This PR introduces a pattern to allow database clones to "inherit" the schema role grants from a common set of schema roles defined for the source db. In essence, it allows SnowDDL to generate and apply the same grants that would get copied by the Snowflake clone operation directly during the resolution process, so that when actual clone operations occur in Snowflake, there is no resource drift (well, actually there is still _some_ resource drift if the clone is executed at the db level, because Snowflake doesn't copy grants on the container, so these grants get "revoked" implicitly by the clone operation; but this is a small concern - these grants can easily be restored explicitly either by running `snowddl apply`, or by executing templated SQL expressions from a query runner / orchestrator)

Furthermore, when `swap` operations are executed between the source db and the db clone (as is common in blue green deploys), there is no resource drift, because the schema roles already have the same grants on _both_ the source db and the clones

This design greatly simplifies grant management for db clones and workflows involves clone-and-swap operations

## Changes
* Introduce `copy_schema_role_grants_to_db_clones` attribute to `DatabaseBlueprint` to describe db clones to which schema role grants should be duplexed
    * This config is intended to be used with `schema_roles:` attribute in `SchemaBlueprint`. If copying source schema role grants over to a cloned db, presumably the user would not want additional schema roles generated for that cloned db, so `schema_roles` should be set to `False` for the cloned db schemas
* Update `DatabaseParser` to accept new `copy_schema_role_grants_to_db_clones` attribute in YAML config
* Update `get_blueprint_*_role()` methods in `SchemaRoleResolver` to duplex schema role grants to cloned db schemas specified in `DatabaseBlueprint.copy_schema_role_grants_to_db_clones` attribute