### PR TITLE
Implement `schema_roles` config inheritance from db yaml config

### DIFF
--- a/snowddl/blueprint/blueprint.py
+++ b/snowddl/blueprint/blueprint.py
@@ -66,6 +66,10 @@ class DatabaseBlueprint(AbstractBlueprint):
     retention_time: Optional[int] = None
     is_sandbox: Optional[bool] = None
     copy_schema_role_grants_to_db_clones: List[str] = []
+    # TODO: add schema_roles to blueprint and update SchemaRoleResolver
+    # to inherit config from db blueprint, so feature is available from
+    # Python config. Currently only available from YAML config
+    # schema_roles: Union[dict, List[str], bool] = []
 
 
 class DatabaseShareBlueprint(AbstractBlueprint):

--- a/snowddl/parser/database.py
+++ b/snowddl/parser/database.py
@@ -23,7 +23,70 @@ database_json_schema = {
             "items": {
                 "type": "string"
             }
-        }
+        },
+        "schema_roles": {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "owner": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "ownership": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "privileges": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                        "enum": ["DYNAMIC TABLES", "STAGES"]
+                                    },
+                                }
+                            }
+                        },
+                        "read": {
+                            "type": "object",
+                            "properties": {
+                                "privileges": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                        "enum": ["DYNAMIC TABLES", "EXTERNAL TABLES", "FILE FORMATS", "FUNCTIONS", "MATERIALIZED VIEWS", "PROCEDURES", "STAGES", "STREAMS", "TABLES", "VIEWS"]
+                                    },
+                                }
+                            }
+                        },
+                        "write": {
+                            "type": "object",
+                            "properties": {
+                                "privileges": {
+                                    "type": "object",
+                                    "propertyNames": {
+                                        "enum": ["STAGES", "SEQUENCES", "TABLES"]
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "boolean"
+                }
+            ],
+        },
     },
     "additionalProperties": False
 }

--- a/snowddl/parser/schema.py
+++ b/snowddl/parser/schema.py
@@ -128,6 +128,7 @@ class SchemaParser(AbstractParser):
                     "is_transient": database_params.get("is_transient", False) or schema_params.get("is_transient", False),
                     "retention_time": schema_params.get("retention_time"),
                     "is_sandbox": database_params.get("is_sandbox", False) or schema_params.get("is_sandbox", False),
+                    "schema_roles": schema_params.get("schema_roles") or database_params.get("schema_roles", [])
                 }
 
                 owner_additional_grants = []
@@ -147,7 +148,7 @@ class SchemaParser(AbstractParser):
                     retention_time=combined_params.get("retention_time", None),
                     is_sandbox=combined_params.get("is_sandbox", False),
                     owner_additional_grants=owner_additional_grants,
-                    schema_roles=schema_params.get("schema_roles", []),
+                    schema_roles=combined_params.get("schema_roles", []),
                     comment=schema_params.get("comment", None),
                 )
 

--- a/snowddl/resolver/schema_role.py
+++ b/snowddl/resolver/schema_role.py
@@ -145,6 +145,8 @@ class SchemaRoleResolver(AbstractRoleResolver):
 
         database_identifiers = self.gather_db_identifiers_for_schema_role_grants(schema_bp)
 
+        # TODO: inherit schema_roles from DatabaseBlueprint, so feature is available from
+        # Python config. Currently only available from YAML config by overloading parser
         schema_roles = schema_bp.schema_roles
 
         default_create_object_types = [
@@ -269,6 +271,8 @@ class SchemaRoleResolver(AbstractRoleResolver):
 
         database_identifiers = self.gather_db_identifiers_for_schema_role_grants(schema_bp)
 
+        # TODO: inherit schema_roles from DatabaseBlueprint, so feature is available from
+        # Python config. Currently only available from YAML config by overloading parser
         schema_roles = schema_bp.schema_roles
 
         default_privileges_map = {
@@ -339,6 +343,8 @@ class SchemaRoleResolver(AbstractRoleResolver):
 
         database_identifiers = self.gather_db_identifiers_for_schema_role_grants(schema_bp)
 
+        # TODO: inherit schema_roles from DatabaseBlueprint, so feature is available from
+        # Python config. Currently only available from YAML config by overloading parser
         schema_roles = schema_bp.schema_roles
 
         default_privileges_map = {


### PR DESCRIPTION
If a database contains many schemas but the same schema role configurations are desired for each, it's much easier to specify these configs at the database level and let the individual schemas inherit them

If one or more schemas requires more specific configuration, the db level configs can be overriden at the schema level. This is known as config "clobbering" - the most specific config always takes precedence. This is similar to how config in dbt works

Taking advantage of inheritance here reduces the footprint of code and configuration we have to manage greatly

NOTE: currently this feature ONLY works with `yaml` config - that is, `schema_roles` is not yet a defined attribute on the `DatabaseBlueprint` class, which means this functionality cannot be implemented directly from a programmatic python config, only from YAML