### PR TITLE
Handle missing grant type dict keys in schema role resolver

### DIFF
--- a/snowddl/resolver/schema_role.py
+++ b/snowddl/resolver/schema_role.py
@@ -111,7 +111,7 @@ class SchemaRoleResolver(AbstractRoleResolver):
 
         elif has_custom_grants:
             custom_grants = schema_roles[schema_role_type] or schema_roles[schema_role_type.upper()]
-            custom_grant_objects = custom_grants[grant_type] or custom_grants[grant_type.upper()]
+            custom_grant_objects = custom_grants.get(grant_type) or custom_grants.get(grant_type.upper(), [])
 
             if grant_type in ["create", "ownership"]:
                 # custom_grant_objects is a list of strings representing object types, just compare 


### PR DESCRIPTION
Use `dict.get(key)` instead of `dict[key]` in `filter_default_schema_role_object_grants()` method. Sometimes a given `grant_type` won't be specified in YAML config, in which case those grants should be ignored. So instead of failing on bracket style access, we use `.get()` and fallback to an empty list default value